### PR TITLE
fix email typo

### DIFF
--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -12,7 +12,7 @@
       <a href="https://www.instagram.com/dcrockyhorror/" target="_blank"><img alt="instagram" src="assets/instagram.png"></a>
     </div>
     <div>
-      sonictranducers.ad@gmail.com<br />
+      sonictransducers.ad@gmail.com<br />
       (202) 783-9494
     </div>
   </div>


### PR DESCRIPTION
Email had a typo, said "sonictranducers" instead of "sonictransducers"